### PR TITLE
docs: fix github workflow badges 🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ is misspeelled
 ## some badges from okp4 discord-bot
 
 [![version](https://img.shields.io/github/v/release/okp4/discord-bot?style=for-the-badge&logo=github)](https://github.com/okp4/discord-bot/releases)
-[![build](https://img.shields.io/github/workflow/status/okp4/discord-bot/Build?label=build&style=for-the-badge&logo=github)](https://github.com/okp4/discord-bot/actions/workflows/build.yml)
-[![lint](https://img.shields.io/github/workflow/status/okp4/discord-bot/Lint?label=lint&style=for-the-badge&logo=github)](https://github.com/okp4/discord-bot/actions/workflows/lint.yml)
-[![test](https://img.shields.io/github/workflow/status/okp4/discord-bot/Test?label=test&style=for-the-badge&logo=github)](https://github.com/okp4/discord-bot/actions/workflows/test.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/okp4/discord-bot/build.yml?branch=main&label=build&style=for-the-badge&logo=github)](https://github.com/okp4/discord-bot/actions/workflows/build.yml)
+[![lint](https://img.shields.io/github/actions/workflow/status/okp4/discord-bot/lint.yml?branch=main&label=lint&style=for-the-badge&logo=github)](https://github.com/okp4/discord-bot/actions/workflows/lint.yml)
+[![test](https://img.shields.io/github/actions/workflow/status/okp4/discord-bot/test.yml?branch=main&label=test&style=for-the-badge&logo=github)](https://github.com/okp4/discord-bot/actions/workflows/test.yml)
 [![codecov](https://img.shields.io/codecov/c/github/okp4/discord-bot?style=for-the-badge&token=K5CYM8TQQY&logo=codecov)](https://codecov.io/gh/okp4/discord-bot)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/okp4/.github/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
This PR fixes github workflow badges after a breaking change on github platform. Everything is explained there : https://github.com/badges/shields/issues/8671

I took advantage of this PR to make the workflow status badges target only the `main` branch.

🤖 This PR is generated by a script.
